### PR TITLE
[EXPORT] WorldFilter, FunctionalWorldFilter, IntervalLengthFilter, FilteredRelation

### DIFF
--- a/src/SoleLogics.jl
+++ b/src/SoleLogics.jl
@@ -118,7 +118,7 @@ include("utils/modal-logic.jl")
 include("types/algebras/relations/filtered-relations.jl")
 export WorldFilter
 include("utils/algebras/relations/filtered-relations.jl")
-export FunctionalWorldFilter
+export FunctionalWorldFilter, FilteredRelation
 include("utils/algebras/frames/full-dimensional-frame/dimensional-world-filters.jl")
 export IntervalLengthFilter
 


### PR DESCRIPTION
World filters are essential for adjusting the granularity of learning in higher-level packages.
In this pr, I simply export various types related to world filtering (I am about to use these in `ModalAssociationRules`).