### PR TITLE
Removed unused constructor

### DIFF
--- a/src/utils/frames/full-dimensional-frame/main.jl
+++ b/src/utils/frames/full-dimensional-frame/main.jl
@@ -57,10 +57,6 @@ struct FullDimensionalFrame{N,W<:AbstractWorld} <: AbstractDimensionalFrame{N,W}
             {N,W<:AbstractWorld}
         new{N,W}(channelsize)
     end
-    function FullDimensionalFrame{N,W}(channelsize::Vararg{Int,N}; silent = true) where
-            {N,W<:AbstractWorld}
-        FullDimensionalFrame{N,W}(channelsize; silent)
-    end
 
     function FullDimensionalFrame(channelsize::Tuple{}, W::Union{Nothing,Type{<:AbstractWorld}} = nothing; silent = true)
         if !isnothing(W)


### PR DESCRIPTION
A suggested by @ReubenJ, I removed the following constructor:
https://github.com/aclai-lab/SoleLogics.jl/blob/d92b61a4f8dc37d3482362e567cf6e653f39755b/src/utils/frames/full-dimensional-frame/main.jl#L60-L63
as I don't think it's needed, and all tests pass, in the hope of fixing the problem with `SymbolServer.jl`/`LanguageServer.jl`. However, I wasn't able to replicate the error on my machine, as VSCode Language Server didn't crash working on `SoleLogics.jl` nor any package using it in my experience. I suggest further investigation.

Since the constructor was added in [this](8d87b85be5a54c664c7ec7c46b2ac3f3136c2cfe) commit allegedly to fix something, I request a review to be sure removing it doesn't cause any issues.