### PR TITLE
Bump new version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SoleLogics"
 uuid = "b002da8f-3cb3-4d91-bbe3-2953433912b5"
-authors = ["Mauro MILELLA", "Giovanni PAGLIARINI", "Edoardo PONSANESI", "Alberto PAPARELLA", "Eduard I. STAN"]
-version = "0.12.0"
+authors = ["Mauro MILELLA", "Giovanni PAGLIARINI", "Alberto PAPARELLA", "Edoardo PONSANESI", "Eduard I. STAN"]
+version = "0.13.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"


### PR DESCRIPTION
I'd like to propose a major release of `SoleLogics.jl` encompassing work on the issues #27, #44, #45, #50, #57, #60.

Features:
- Aliases for common multi-modal logics (LTL[F,P], CL, HS, RCC8) (#44)
- Optimized many-valued operations (FiniteIndexAlgebras and relative structures are now the default version) (#27)
  **Warning:** FiniteIndex* types (e.g., FiniteIndexAlgebra) are not supported anymore, as their behavior shifted to Finite* types (e.g., FiniteAlgebra)

Fixes:
- Compass logic relations (#45)
- Ensured type stability for accessible functions for HS relations (#50)
- Updated `cirrus.yml` with freebsd-family 14.2 (#57)

Ohters:
- Substituted `@assert` occurrences with error() in ManyValuedlogics (#60)