### PR TITLE
Size method for GeometricalWorld

### DIFF
--- a/src/SoleLogics.jl
+++ b/src/SoleLogics.jl
@@ -98,11 +98,10 @@ export KripkeStructure
 export truthtype, worldtype
 
 export AbstractWorld
-
 export AbstractWorlds, Worlds
 
 export OneWorld
-export Point, Point1D, Point2D, Point3D
+export GeometricalWorld, Point, Point1D, Point2D, Point3D
 export Interval, Interval2D
 
 export AbstractRelation

--- a/src/SoleLogics.jl
+++ b/src/SoleLogics.jl
@@ -103,6 +103,7 @@ export AbstractWorlds, Worlds
 export OneWorld
 export GeometricalWorld, Point, Point1D, Point2D, Point3D
 export Interval, Interval2D
+export RelativeGeometricalWorld
 
 export AbstractRelation
 

--- a/src/utils/frames/worlds/geometrical-worlds.jl
+++ b/src/utils/frames/worlds/geometrical-worlds.jl
@@ -194,7 +194,8 @@ struct Interval2D{T<:Real} <: GeometricalWorld
 end
 
 # Base.size(w::Interval2D) = (Base.length(w.x), Base.length(w.y))
-Base.length(w::Interval2D) = prod(Base.length(w.x), Base.length(w.y))
+Base.length(w::Interval2D) = Base.length(w.x) * Base.length(w.y)
+Base.size(w::Interval2D) = (Base.length(w.x), Base.length(w.y))
 
 inlinedisplay(w::Interval2D) = "($(w.x)×$(w.y))"
 

--- a/src/utils/frames/worlds/geometrical-worlds.jl
+++ b/src/utils/frames/worlds/geometrical-worlds.jl
@@ -135,6 +135,7 @@ end
 
 # Base.size(w::Interval) = (Base.length(w),)
 Base.length(w::Interval) = (w.y - w.x)
+Base.size(w::Interval) = (Base.length(w),)
 
 inlinedisplay(w::Interval) = "($(w.x)−$(w.y))"
 

--- a/src/utils/frames/worlds/geometrical-worlds.jl
+++ b/src/utils/frames/worlds/geometrical-worlds.jl
@@ -44,6 +44,7 @@ end
 
 # Base.size(w::Point) = (1,) # TODO maybe not
 Base.length(w::Point) = 1
+Base.size(::Point) = ()
 
 inlinedisplay(w::Point) = "❮$(join(w.xyz, ","))❯"
 

--- a/src/utils/frames/worlds/geometrical-worlds.jl
+++ b/src/utils/frames/worlds/geometrical-worlds.jl
@@ -193,7 +193,6 @@ struct Interval2D{T<:Real} <: GeometricalWorld
     Interval2D(x::Tuple{T,T}, y::Tuple{T,T}) where {T} = Interval2D{T}(x,y)
 end
 
-# Base.size(w::Interval2D) = (Base.length(w.x), Base.length(w.y))
 Base.length(w::Interval2D) = Base.length(w.x) * Base.length(w.y)
 Base.size(w::Interval2D) = (Base.length(w.x), Base.length(w.y))
 

--- a/src/utils/frames/worlds/geometrical-worlds.jl
+++ b/src/utils/frames/worlds/geometrical-worlds.jl
@@ -221,6 +221,7 @@ end
 innerworld(w::RelativeGeometricalWorld) = w.w
 @forward RelativeGeometricalWorld.w (
     Base.length,
+    Base.size,
     inlinedisplay,
     goeswithdim,
     nparameters,

--- a/test/frames/worlds.jl
+++ b/test/frames/worlds.jl
@@ -6,6 +6,7 @@ using Test
 @test_nowarn SoleLogics.Point(1,2,3)
 @test_nowarn SoleLogics.Point((1,2,3),)
 @test all([SoleLogics.goeswithdim.(SoleLogics.Point{N}, N) for N in 1:10])
+@test Base.length(Point(1,2,3,4)) == 1
 @test Base.size(Point(1,2,3,4)) == ()
 
 @test_nowarn SoleLogics.Interval(1,2)
@@ -14,6 +15,8 @@ using Test
 @test !SoleLogics.goeswithdim(Interval(1,2), 2)
 @test SoleLogics.goeswithdim(Interval, 1)
 @test !SoleLogics.goeswithdim(Interval, 2)
+@test Base.length(Interval(12,32)) == 20
+@test Base.size(Interval(12,32)) == (20,)
 
 @test_nowarn SoleLogics.Interval2D((1,2),(3,4))
 @test_nowarn SoleLogics.Interval2D(Interval(1,2),Interval(3,4))

--- a/test/frames/worlds.jl
+++ b/test/frames/worlds.jl
@@ -22,6 +22,8 @@ using Test
 @test_nowarn SoleLogics.Interval2D(Interval(1,2),Interval(3,4))
 @test !SoleLogics.goeswithdim(Interval2D, 1)
 @test SoleLogics.goeswithdim(Interval2D, 2)
+@test Base.length(Interval2D((1,3), (3,10))) == 14
+@test Base.size(Interval2D((1,3), (3,10))) == (2,7)
 
 fr1D = @test_nowarn SoleLogics.FullDimensionalFrame(5)
 fr2D = @test_nowarn SoleLogics.FullDimensionalFrame(1,2)

--- a/test/frames/worlds.jl
+++ b/test/frames/worlds.jl
@@ -6,6 +6,7 @@ using Test
 @test_nowarn SoleLogics.Point(1,2,3)
 @test_nowarn SoleLogics.Point((1,2,3),)
 @test all([SoleLogics.goeswithdim.(SoleLogics.Point{N}, N) for N in 1:10])
+@test Base.size(Point(1,2,3,4)) == ()
 
 @test_nowarn SoleLogics.Interval(1,2)
 @test_nowarn SoleLogics.Interval((1,2),)
@@ -35,10 +36,9 @@ fr2D = @test_nowarn SoleLogics.FullDimensionalFrame(1,2)
   @test_broken (@test_nowarn accessibles(fr1D, rw3))
   @test_broken (@test_nowarn accessibles(fr1D, rw4))
   # TODO test several cases of accessibles
-# 
+#
 end
 
 @test Base.isconcretetype(Base.return_types(accessibles, typeof.((SoleLogics.FullDimensionalFrame((5,),), [Interval(2,3),Interval(2,4)], SoleLogics.IA_L)))[1])
 @test_broken Base.isconcretetype(eltype(Base.return_types(accessibles, typeof.((SoleLogics.FullDimensionalFrame((5,),), [Interval(2,3),Interval(2,4)], SoleLogics.IA_L)))[1]))
 @test_broken ((@inferred eltype(accessibles(SoleLogics.FullDimensionalFrame((5,),), [Interval(2,3),Interval(2,4)], SoleLogics.IA_L))) == Interval{Int})
-


### PR DESCRIPTION
This pr wants to solve #68 .

Now, every definition in src/utils/frames/worlds has a well-defined length and size method. In particular, I am talking about all the `GeometricalWorld` concrete types (`Point`, `Interval`, `Interval2D`, `RelativeGeometricalWorld`).

I also added the exports for `GeometricalWorld` and `RelativeGeometricalWorld`.

I added the tests to cover the (few) lines introduced with this pr.