### PR TITLE
Fix/106 Non reproducible behaviour of randmodel

### DIFF
--- a/src/generation/models.jl
+++ b/src/generation/models.jl
@@ -20,6 +20,8 @@ end
     facts::Vector{<:SyntaxLeaf},
     truthvalues::Union{AbstractAlgebra,AbstractVector{<:Truth}}
 )
+    rng = initrng(rng) 
+
     truthvalues = inittruthvalues(truthvalues)
     fr = randframe(rng, nworlds, nedges)
 

--- a/src/generation/models.jl
+++ b/src/generation/models.jl
@@ -24,7 +24,7 @@ end
     fr = randframe(rng, nworlds, nedges)
 
     valuation = Dict(
-        [w => TruthDict([f => rand(truthvalues) for f in facts]) for w in fr.worlds]
+        [w => TruthDict([f => rand(rng, truthvalues) for f in facts]) for w in fr.worlds]
     )
 
     return KripkeStructure(fr, valuation)

--- a/test/generation/models.jl
+++ b/test/generation/models.jl
@@ -2,10 +2,46 @@ using Random
 
 @testset "randframe + randmodel" begin
 
-@test_nowarn randframe(42, 10, 20)
-@test_nowarn randframe(Random.MersenneTwister(42), 10, 20)
+    # Check whether two randframes are equal
+    # TODO: create and export this dispatch
+    function _isequal_frame(f1, f2)
+        return f1.worlds == f2.worlds && f1.graph == f2.graph
+    end
 
-@test_nowarn randmodel(42, 5, 10, [Atom("s"), Atom("p")], BooleanAlgebra())
-@test_nowarn randmodel(42, 5, 10, [Atom("s"), Atom("p")], BooleanAlgebra())
+    # TODO: this is an important todo;
+    # right now, this function is the same as _isequal_frame, since assignments
+    # are not considered.
+    #
+    # The problem is that checking hte equality of two TruthDicts is deceptive;
+    # try to create a randmodel `m` and then run:
+    # m == deepcopy(m)
+    # or 
+    # m.assignments == deepcopy(m.assignments)
+    function _isequal_model(m1, m2)
+        return _isequal_frame(m1.frame, m2.frame)
+    end
 
+    # randframe and randmodel seed
+    _rfrmseed = 42
+    _atoms = [Atom("s"), Atom("p")]
+    _ba = BooleanAlgebra()
+
+    @test_nowarn randframe(_rfrmseed, 10, 20)
+    @test_nowarn randframe(Random.MersenneTwister(_rfrmseed), 10, 20)
+
+    randframes1 = [randframe(_rfrmseed + i, 10, 20) for i in 1:10]
+    randframes2 = [randframe(_rfrmseed + i, 10, 20) for i in 1:10]
+
+
+    @test all(t -> t == 1,
+        [_isequal_frame(f1, f2) for (f1, f2) in zip(randframes1, randframes2)],)
+
+
+    @test_nowarn randmodel(_rfrmseed, 5, 10, _atoms, _ba)
+
+    randmodels1 = [randmodel(_rfrmseed + i, 5, 10, _atoms, _ba) for i in 1:10]
+    randmodels2 = [randmodel(_rfrmseed + i, 5, 10, _atoms, _ba) for i in 1:10]
+
+    @test all(t -> t == 1,
+        [_isequal_model(m1, m2) for (m1, m2) in zip(randmodels1, randmodels2)],)
 end


### PR DESCRIPTION
This pr addresses #106 .

The behaviour of `randmodel` was not reproducible.

I initialized the `rng` using the `initrng` helper, and replaced

```julia
[w => TruthDict([f => rand(truthvalues) for f in facts]) for w in fr.worlds]
```

with

```julia
[w => TruthDict([f => rand(rng, truthvalues) for f in facts]) for w in fr.worlds]
```

(Note how the global rng was leveraged in the first call).