### PR TITLE
Add checkable witnesses and serialization schema

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,7 +18,34 @@ SoleLogics.jl allows manipulation of:
 - [Formulas](https://en.wikipedia.org/wiki/Well-formed_formula) (e.g., syntax trees, DNFs, CNFs): random generation, parsing, minimization;
 - [Interpretations](https://en.wikipedia.org/wiki/Interpretation_(logic)) (e.g., propositional assignments, [Kripke structures](https://en.wikipedia.org/wiki/Kripke_structure_(model_checking)));
 - Algorithms for evaluating the truth of a formula on an interpretation ([model checking](https://en.wikipedia.org/wiki/Model_checking));
-- Interfaces to Z3, for evaluating the validity/satisfiability of a propositional formula.
+- Opt-in, independently checkable witnesses and a process-boundary serialization schema for finite Kripke model checks.
+
+
+## Check witnesses and serialization
+
+`check(φ, model, world)` keeps its historical Boolean return value.  Pass
+`witness=true` to obtain `(result, witness)`, where [`CheckWitness`](@ref)
+contains the satisfying-world set for every subformula, atom valuations, and
+the accessibility edges used by modal operators.  The witness is suitable for
+independent bottom-up verification over the same finite frame.
+
+[`serialize_check`](@ref) returns a plain nested `Dict{String,Any}` with the
+formula, frame, result, witness, `schema_version`, and `engine_version`; it
+adds no JSON dependency.  For example, with any JSON package already chosen
+by the caller:
+
+```julia
+using JSON3
+JSON3.write(serialize_check(φ, model, world))
+```
+
+The schema uses `w1`, `w2`, ... as per-result world identifiers, stores frame
+edges as `{"from", "to"}` objects, and represents the formula as a
+recursive `{"token", "kind", "children"}` tree.
+
+The former documentation claim about a Z3 validity/satisfiability interface
+was stale: this source has no Z3 dependency or corresponding API, so it is not
+listed as a feature.
 
 ## Installation
 

--- a/src/SoleLogics.jl
+++ b/src/SoleLogics.jl
@@ -53,7 +53,7 @@ include("types/parse.jl")
 
 
 export Interpretation
-export interpret, check
+export interpret, check, CheckWitness, serialize_check
 export DefaultCheckAlgorithm
 
 include("types/interpretation.jl")

--- a/src/types/interpretation.jl
+++ b/src/types/interpretation.jl
@@ -120,6 +120,31 @@ This algorithm is not optimized for special cases.
 struct DefaultCheckAlgorithm <: CheckAlgorithm end
 
 """
+    CheckWitness
+
+A checkable, opt-in witness produced by `check(...; witness=true)`.  The
+`satisfying_worlds` dictionary contains the satisfying worlds for every
+(normalized) subformula.  `atom_valuations` contains the truth value of every
+atom in those subformulas on every frame world, and `accessibility` contains
+edge lists obtained from the frame's `accessibles` methods.  The `formula`
+field is the formula to which the witness applies (it is normalized when
+normalization is enabled).
+
+The witness is deliberately a data object: an independent evaluator can
+recompute each entry bottom-up from these fields and the formula's connective
+semantics without invoking SoleLogics' checker.
+"""
+struct CheckWitness
+    formula::SyntaxTree
+    evaluated_world::Any
+    result::Bool
+    satisfying_worlds::Dict
+    atom_valuations::Dict
+    accessibility::Dict
+    worlds::Vector
+end
+
+"""
     check(
         [algo::CheckAlgorithm,]
         φ::Formula,
@@ -156,7 +181,7 @@ false
 
 See also [`check`](@ref), [`interpret`](@ref), [`Interpretation`](@ref).
 """
-function check(φ::Formula, args...; kwargs...)::Union{Bool, Vector{Bool}}
+function check(φ::Formula, args...; kwargs...)::Union{Bool, Vector{Bool}, Tuple{Bool, CheckWitness}}
     check(DefaultCheckAlgorithm(), φ, args...; kwargs...)
 end
 

--- a/src/utils/modal-logic/modal-logic.jl
+++ b/src/utils/modal-logic/modal-logic.jl
@@ -283,6 +283,148 @@ struct AnyWorld end
 #     end
 # end
 
+# Build relation-labelled edge lists through the same accessibility interface
+# used by collateworlds.  The default modal connectives use the unimodal
+# accessibility method; relational connectives use their relation.
+function _witness_accessibility(fr, formula::SyntaxTree, ::Type{W}) where {W}
+    requests = Tuple{String,Any}[]
+    for ψ in unique(subformulas(formula))
+        tok = token(ψ)
+        if tok isa AbstractRelationalConnective
+            label = syntaxstring(relation(tok))
+            any(first(x) == label for x in requests) || push!(requests, (label, relation(tok)))
+        elseif tok isa Connective && ismodal(tok)
+            any(first(x) == "default" for x in requests) || push!(requests, ("default", nothing))
+        end
+    end
+    edges = Dict{String,Vector{Tuple{W,W}}}()
+    worlds = collect(allworlds(fr))
+    for (label, rel) in requests
+        edges[label] = if isnothing(rel)
+            [(from, to) for from in worlds for to in accessibles(fr, from)]
+        elseif rel == globalrel
+            targets = collect(accessibles(fr, rel))
+            [(from, to) for from in worlds for to in targets]
+        else
+            [(from, to) for from in worlds for to in accessibles(fr, from, rel)]
+        end
+    end
+    edges
+end
+
+function _make_check_witness(
+    formula::SyntaxTree,
+    w,
+    result::Bool,
+    memo_structure,
+    i::AbstractKripkeStructure,
+)
+    fr = frame(i)
+    W = worldtype(i)
+    satisfying = Dict{SyntaxTree,Worlds{W}}()
+    for ψ in unique(subformulas(formula))
+        # Copy the sets so a witness remains stable if a caller later mutates a
+        # supplied memo dictionary.
+        satisfying[tree(ψ)] = Worlds{W}(collect(memo_structure[tree(ψ)]))
+    end
+    atoms = Dict{SyntaxTree,Dict{W,Bool}}()
+    worlds = collect(allworlds(fr))
+    for ψ in unique(subformulas(formula))
+        tok = token(ψ)
+        if tok isa AbstractAtom
+            atoms[tree(ψ)] = Dict{W,Bool}(world => istop(interpret(tok, i, world)) for world in worlds)
+        end
+    end
+    CheckWitness(
+        formula,
+        w,
+        result,
+        satisfying,
+        atoms,
+        _witness_accessibility(fr, formula, W),
+        worlds,
+    )
+end
+
+function _schema_formula(ψ::SyntaxTree)
+    tok = token(ψ)
+    Dict{String,Any}(
+        "token" => syntaxstring(tok),
+        "kind" => tok isa AbstractAtom ? "atom" : tok isa Connective ? "connective" : "truth",
+        "children" => [_schema_formula(child) for child in children(ψ)],
+    )
+end
+
+function _schema_witness(witness::CheckWitness)
+    worlds = unique(vcat(witness.worlds,
+                         [endpoint for edge_list in values(witness.accessibility) for edge in edge_list for endpoint in edge]...))
+    ids = Dict{Any,String}(world => "w$(n)" for (n, world) in enumerate(worlds))
+    sets = Dict{String,Any}(
+        syntaxstring(ψ) => [ids[world] for world in worldsψ]
+        for (ψ, worldsψ) in witness.satisfying_worlds
+    )
+    valuations = Dict{String,Any}(
+        syntaxstring(atom) => Dict{String,Any}(ids[world] => value for (world, value) in vals)
+        for (atom, vals) in witness.atom_valuations
+    )
+    Dict{String,Any}(
+        "formula" => _schema_formula(witness.formula),
+        "evaluated_world" => isnothing(witness.evaluated_world) || witness.evaluated_world isa AnyWorld ? nothing : ids[witness.evaluated_world],
+        "result" => witness.result,
+        "satisfying_worlds" => sets,
+        "atom_valuations" => valuations,
+        "accessibility" => Dict{String,Any}(
+            relation => [Dict{String,Any}("from" => ids[from], "to" => ids[to]) for (from, to) in edges]
+            for (relation, edges) in witness.accessibility
+        ),
+        "worlds" => [Dict{String,Any}("id" => ids[world], "label" => inlinedisplay(world)) for world in worlds],
+    )
+end
+
+"""
+    serialize_check(φ, i, w=nothing; kwargs...)
+
+Return a plain nested `Dict{String,Any}` containing a language-agnostic
+serialization of a finite Kripke frame, formula, result, and check witness.
+The dictionary has keys `schema_version`, `engine_version`, `frame`, and
+`witness`; world identifiers are stable within one result and are used by all
+frame and witness edge/valuation tables.  No JSON package is required.  For
+example, callers may write it with `JSON3.write(serialize_check(φ, i, w))`.
+"""
+function serialize_check(
+    φ::SyntaxTree,
+    i::AbstractKripkeStructure,
+    w::Union{Nothing,AnyWorld,<:AbstractWorld}=nothing;
+    use_memo=nothing,
+    perform_normalization::Bool=true,
+    memo_max_height::Union{Nothing,Int}=nothing,
+)
+    result, witness = check(
+        φ, i, w;
+        witness=true,
+        use_memo=use_memo,
+        perform_normalization=perform_normalization,
+        memo_max_height=memo_max_height,
+    )
+    schema_witness = _schema_witness(witness)
+    Dict{String,Any}(
+        "schema_version" => "solelogics.check.v1",
+        "engine_version" => string(Base.pkgversion(@__MODULE__)),
+        "frame" => Dict{String,Any}(
+            "worlds" => schema_witness["worlds"],
+            "accessibility" => schema_witness["accessibility"],
+        ),
+        "formula" => schema_witness["formula"],
+        "result" => result,
+        "witness" => Dict{String,Any}(
+            "evaluated_world" => schema_witness["evaluated_world"],
+            "result" => result,
+            "satisfying_worlds" => schema_witness["satisfying_worlds"],
+            "atom_valuations" => schema_witness["atom_valuations"],
+        ),
+    )
+end
+
 """
     function check(
         φ::SyntaxTree,
@@ -291,7 +433,11 @@ struct AnyWorld end
         use_memo::Union{Nothing,AbstractDict{<:Formula,<:Vector{<:AbstractWorld}}} = nothing,
         perform_normalization::Bool = true,
         memo_max_height::Union{Nothing,Int} = nothing,
-    )::Bool
+        witness::Bool = false,
+    )
+
+When `witness=false` (the default), return the historical `Bool`.  With
+`witness=true`, return `(result, witness)` where `witness isa CheckWitness`.
 
 Check a formula on a specific word in a [`KripkeStructure`](@ref).
 
@@ -345,8 +491,9 @@ function check(
     w::Union{Nothing,AnyWorld,<:AbstractWorld} = nothing;
     use_memo::Union{Nothing,AbstractDict{<:Formula,<:Vector{<:AbstractWorld}}} = nothing,
     perform_normalization::Bool = true,
-    memo_max_height::Union{Nothing,Int} = nothing
-)::Bool
+    memo_max_height::Union{Nothing,Int} = nothing,
+    witness::Bool = false
+)::Union{Bool,Tuple{Bool,CheckWitness}}
     W = worldtype(i)
 
     if isnothing(w)
@@ -383,7 +530,7 @@ function check(
     (_f, _c) = filter, collect
     # (_f, _c) = Iterators.filter, identity
 
-    if !hasformula(memo_structure, φ)
+    if witness || !hasformula(memo_structure, φ)
         for ψ in unique(subformulas(φ))
             if !isnothing(memo_max_height) && height(ψ) > memo_max_height
                 push!(forget_list, ψ)
@@ -417,13 +564,15 @@ function check(
         end
     end
 
+    witness_data = witness ? _make_check_witness(φ, w, ret, memo_structure, i) : nothing
+
     if !isnothing(memo_max_height)
         for ψ in forget_list
             delete!(memo_structure, ψ)
         end
     end
 
-    return ret
+    return witness ? (ret, witness_data) : ret
 end
 
 """

--- a/test/modal-logic/modal-logic.jl
+++ b/test/modal-logic/modal-logic.jl
@@ -375,3 +375,13 @@ serialized = serialize_check(witness_formula, kstruct, worlds[1])
 @test serialized["engine_version"] == "0.13.7"
 @test serialized["result"] == true
 @test haskey(serialized["frame"], "accessibility")
+
+# Relational witnesses retain the relation label and enumerate global edges.
+global_formula = diamond(globalrel)(p)
+global_result, global_witness = check(global_formula, kstruct, worlds[1]; witness=true)
+@test global_result
+@test haskey(global_witness.accessibility, "G")
+@test Set(global_witness.accessibility["G"]) == Set((from, to) for from in worlds for to in worlds)
+global_serialized = serialize_check(global_formula, kstruct, worlds[1])
+@test haskey(global_serialized["frame"]["accessibility"], "G")
+@test length(global_serialized["frame"]["accessibility"]["G"]) == length(worlds)^2

--- a/test/modal-logic/modal-logic.jl
+++ b/test/modal-logic/modal-logic.jl
@@ -317,3 +317,61 @@ kstruct4 = KripkeStructure(kframe4, valuation4)
 ### #
 ### #  Memory estimate: 76.64 MiB, allocs estimate: 1932369.
 ###
+
+
+##### checkable witness and serialization ###############################################
+
+# Re-evaluate the witness without using `check`, `collateworlds`, or the frame's
+# accessibility methods for the modal step.  This is intentionally a small,
+# independent evaluator for the finite frame used above.
+function independently_verify(witness, frame)
+    worlds = collect(allworlds(frame))
+    edges = witness.accessibility["default"]
+    sets = Dict{SyntaxTree,Set{eltype(worlds)}}()
+    for ψ in unique(subformulas(witness.formula))
+        tok = token(ψ)
+        values = if tok isa AbstractAtom
+            Set(world for world in worlds if witness.atom_valuations[tree(ψ)][world])
+        elseif tok === ¬
+            setdiff(Set(worlds), sets[tree(first(children(ψ)))])
+        elseif tok === ∧
+            intersect(sets[tree(children(ψ)[1])], sets[tree(children(ψ)[2])])
+        elseif tok === ∨
+            union(sets[tree(children(ψ)[1])], sets[tree(children(ψ)[2])])
+        elseif tok === □
+            childset = sets[tree(first(children(ψ)))]
+            Set(world for world in worlds if all(
+                to in childset for (from, to) in edges if from == world))
+        elseif tok === ◊
+            childset = sets[tree(first(children(ψ)))]
+            Set(world for world in worlds if any(
+                to in childset for (from, to) in edges if from == world))
+        else
+            error("unexpected token in independent verifier: $tok")
+        end
+        sets[tree(ψ)] = values
+        @test values == Set(witness.satisfying_worlds[tree(ψ)])
+    end
+    sets
+end
+
+witness_formula = BOX(p ∨ q)
+verified_result, verified_witness = check(witness_formula, kstruct, worlds[1]; witness=true)
+@test verified_result
+@test verified_witness.result == verified_result
+independent_sets = independently_verify(verified_witness, kframe)
+@test worlds[1] in independent_sets[tree(verified_witness.formula)]
+@test Set(verified_witness.accessibility["default"]) ==
+    Set((from, to) for from in worlds for to in accessibles(kframe, from))
+
+falsified_result, falsified_witness = check(BOX(¬p), kstruct, worlds[1]; witness=true)
+@test !falsified_result
+falsified_sets = independently_verify(falsified_witness, kframe)
+@test !(worlds[1] in falsified_sets[tree(falsified_witness.formula)])
+
+serialized = serialize_check(witness_formula, kstruct, worlds[1])
+@test serialized isa Dict{String,Any}
+@test serialized["schema_version"] == "solelogics.check.v1"
+@test serialized["engine_version"] == "0.13.7"
+@test serialized["result"] == true
+@test haskey(serialized["frame"], "accessibility")


### PR DESCRIPTION
Closes #109.

## What changed

- Added opt-in `check(...; witness=true)`, returning `(result, CheckWitness)` while the default path remains a Boolean. The witness includes the normalized formula, evaluated world/result, satisfying-world sets for every subformula, atom valuations, frame worlds, and accessibility edges collected through the existing `accessibles` interface.
- Added `serialize_check`, returning a plain nested `Dict{String,Any}` with a documented `solelogics.check.v1` schema, formula tree, frame/world IDs and edges, result, witness, and engine version. No JSON dependency was added.
- Added independent bottom-up witness verification tests for satisfied and falsified formulas, plus serialization coverage.
- Removed the stale Z3 feature claim from the docs: the source has no Z3 dependency or corresponding API.

Validation: `julia --project=. -e 'using Pkg; Pkg.test()'` passes (115007 passed, 16 existing broken tests). The default no-keyword path was also checked to return `Bool`.

This is an additive proposal and has not been maintainer-reviewed. Please reshape the API, names, and witness/schema structure as you prefer; maintainer naming and structure preferences win over this implementation.
