### PR TITLE
Fix propositional check for Dict to return false for absent atoms (fixes #111)

### DIFF
--- a/src/utils/propositional-logic.jl
+++ b/src/utils/propositional-logic.jl
@@ -443,7 +443,7 @@ false
 
 See also [`Atom`](@ref).
 """
-check(::CheckAlgorithm, a::Atom, i::AbstractDict) = haskey(a,i) ? Base.getindex(i, value(a)) : nothing
+check(::CheckAlgorithm, a::Atom, i::AbstractDict) = haskey(a,i) ? istop(convert(Truth, Base.getindex(i, value(a)))) : false
 
 #############################################################################################
 ##################################### AbstractVector ########################################

--- a/test/propositional.jl
+++ b/test/propositional.jl
@@ -7,6 +7,11 @@
     @test !d0["b"]
     @test check(parseformula("a ∧ c"), d0)
 
+    d_issue = Dict([1 => ⊤, 2 => ⊥])
+    @test check(Atom(1), d_issue) === true
+    @test check(Atom(2), d_issue) === false
+    @test check(Atom(3), d_issue) === false
+
     v0 = ["a", "c"]
     @test "a" in v0
     @test !("b" in v0)
@@ -98,6 +103,11 @@ end
     @test_nowarn DefaultedTruthDict(Atom(1.0) => true)
 
     @test !check(parseformula("a ∧ b"), DefaultedTruthDict(["a"]))
+
+    td_def = DefaultedTruthDict([1 => ⊤, 2 => ⊥], ⊥)
+    @test check(Atom(1), td_def) === true
+    @test check(Atom(2), td_def) === false
+    @test check(Atom(3), td_def) === false
 
     @test DefaultedTruthDict(["p", "q"])["p"] |> istop
     @test DefaultedTruthDict(["p", "q"])[Atom("p")] |> istop


### PR DESCRIPTION
Resolves #111, where `check(a::Atom, i::AbstractDict)` returned `nothing` for an atom absent from the dictionary — disagreeing with both its own docstring and the declared `::Union{Bool, Vector{Bool}}` return type, and reaching callers as a `MethodError` rather than failing where the problem is.

### The choice, and why

We took the closed-world reading: an absent atom is `false`.

- **The docstring already says so.** `src/utils/propositional-logic.jl` documents `check(Atom(3), Dict([1 => ⊤, 2 => ⊥]))` returning `false`.
- **The declared return type already says so.** `src/types/interpretation.jl` declares `::Union{Bool, Vector{Bool}}`, which `nothing` does not inhabit.
- **The other interpretations already behave this way.** An absent atom on an `AbstractVector` or a `DefaultedTruthDict` evaluates to `false`; `DefaultedTruthDict` exists precisely to supply a value for unlisted atoms.

The alternative is defensible: refuse, raising a clear error naming the missing atom, and amend the docstring and return type to match. That is a semantic decision in your package rather than ours — **if you prefer it, say so and we will rework this PR.** What matters either way is that the implementation, the docstring and the declared type stop disagreeing.

### Changes

- `check(::CheckAlgorithm, a::Atom, i::AbstractDict)` now returns `istop(convert(Truth, i[value(a)]))` when the atom is present and `false` when it is absent. It goes through the existing `Base.convert(::Type{Truth}, ::Bool)` so dictionaries holding raw `Bool` values and dictionaries holding `Truth` values are treated alike, and **no new methods are added to any existing generic**.
- Tests in `test/propositional.jl` covering a present atom, an absent atom, and the docstring's own example, for both a plain `Dict` and a `DefaultedTruthDict`.

One line of source and ten of tests; nothing else in the package changes.
