### PR TITLE
Fix equality relation and hashing for TruthDict and DefaultedTruthDict (#108)

### DIFF
--- a/src/utils/propositional-logic.jl
+++ b/src/utils/propositional-logic.jl
@@ -226,6 +226,18 @@ end
     Base.keys, Base.values,
 )
 
+function Base.isequal(a::TruthDict, b::TruthDict)
+    return Base.isequal(a.truth, b.truth)
+end
+
+function Base.:(==)(a::TruthDict, b::TruthDict)
+    return Base.isequal(a, b)
+end
+
+function Base.hash(a::TruthDict, h::UInt)
+    return Base.hash(a.truth, Base.hash(TruthDict, h))
+end
+
 ############################################################################################
 ################################## DefaultedTruthDict ######################################
 ############################################################################################
@@ -354,6 +366,18 @@ end
     Base.keys,
     Base.values,
 )
+
+function Base.isequal(a::DefaultedTruthDict, b::DefaultedTruthDict)
+    return Base.isequal(a.truth, b.truth) && Base.isequal(a.default_truth, b.default_truth)
+end
+
+function Base.:(==)(a::DefaultedTruthDict, b::DefaultedTruthDict)
+    return Base.isequal(a, b)
+end
+
+function Base.hash(a::DefaultedTruthDict, h::UInt)
+    return Base.hash(a.default_truth, Base.hash(a.truth, Base.hash(DefaultedTruthDict, h)))
+end
 
 
 ############################################################################################

--- a/test/propositional.jl
+++ b/test/propositional.jl
@@ -84,6 +84,20 @@ end
     @test_throws MethodError interpret("r", TruthDict(["p", "q"])) isa AbstractAtom
     @test interpret(Atom("r"), TruthDict(["p", "q"])) isa AbstractAtom
 
+    # Equality and hashing (#108)
+    td_a = TruthDict(["p" => true, "q" => false])
+    td_b = TruthDict(["p" => true, "q" => false])
+    td_c = TruthDict(["p" => true, "q" => true])
+    @test td_a == deepcopy(td_a)
+    @test isequal(td_a, deepcopy(td_a))
+    @test td_a == td_b
+    @test isequal(td_a, td_b)
+    @test td_a != td_c
+    @test !isequal(td_a, td_c)
+    @test hash(td_a) == hash(deepcopy(td_a))
+    @test hash(td_a) == hash(td_b)
+    @test length(Set([td_a, deepcopy(td_a), td_b])) == 1
+    @test Dict(td_a => 1)[deepcopy(td_a)] == 1
 end
 
 @testset "DefaultedTruthDict" begin
@@ -109,4 +123,26 @@ end
     @test_throws MethodError interpret("r", DefaultedTruthDict(["p", "q"])) |> isbot
     @test interpret(Atom("r"), DefaultedTruthDict(["p", "q"])) |> isbot
 
+    # Equality and hashing (#108)
+    dtd_a = DefaultedTruthDict(["p" => true, "q" => false], TOP)
+    dtd_b = DefaultedTruthDict(["p" => true, "q" => false], TOP)
+    dtd_c = DefaultedTruthDict(["p" => true, "q" => false], BOT)
+    dtd_d = DefaultedTruthDict(["p" => true, "q" => true], TOP)
+    @test dtd_a == deepcopy(dtd_a)
+    @test isequal(dtd_a, deepcopy(dtd_a))
+    @test dtd_a == dtd_b
+    @test isequal(dtd_a, dtd_b)
+    @test dtd_a != dtd_c
+    @test !isequal(dtd_a, dtd_c)
+    @test dtd_a != dtd_d
+    @test !isequal(dtd_a, dtd_d)
+    @test hash(dtd_a) == hash(deepcopy(dtd_a))
+    @test hash(dtd_a) == hash(dtd_b)
+    @test length(Set([dtd_a, deepcopy(dtd_a), dtd_b])) == 1
+    @test Dict(dtd_a => 1)[deepcopy(dtd_a)] == 1
+end
+
+@testset "Issue #108 reproduction" begin
+    my_model = randmodel(42, 5, 10, [Atom("p"), Atom("q")], BooleanAlgebra())
+    @test my_model.assignment == deepcopy(my_model.assignment)
 end


### PR DESCRIPTION
This PR resolves #108 by defining Base.isequal, Base.:(==), and Base.hash for TruthDict and DefaultedTruthDict.

### Changes
- Implemented Base.isequal, Base.:(==), and Base.hash for TruthDict based on its wrapped dictionary.
- Implemented Base.isequal, Base.:(==), and Base.hash for DefaultedTruthDict based on its wrapped dictionary and default_truth value.
- Added unit tests in test/propositional.jl covering equality, inequality, hash-consistency (dictionary/set lookup), and the maintainer's reproduction case from #108.