### PR TITLE
Check that an Interval is an interval (#47)

### DIFF
--- a/src/utils/frames/worlds/geometrical-worlds.jl
+++ b/src/utils/frames/worlds/geometrical-worlds.jl
@@ -127,10 +127,8 @@ struct Interval{T<:Real} <: GeometricalWorld
     # TODO needed?
     Interval(w::Interval) = Interval(w.x,w.y)
 
-    Interval{T}(x::T,y::T) where {T} = new{T}(x,y)
+    Interval{T}(x::T,y::T) where {T} = x < y ? new{T}(x,y) : error("Cannot instantiate Interval(x=$(x),y=$(y)): x must be less than y")
     Interval(x::T,y::T) where {T} = Interval{T}(x,y)
-    # TODO: perhaps check x<y (and  x<=N, y<=N ?), but only in debug mode.
-    # Interval(x,y) = x>0 && y>0 && x < y ? new(x,y) : error("Cannot instantiate Interval(x={$x},y={$y})")
 end
 
 # Base.size(w::Interval) = (Base.length(w),)

--- a/test/modal-logic/frames/worlds.jl
+++ b/test/modal-logic/frames/worlds.jl
@@ -10,6 +10,9 @@ using Test
 @test Base.size(Point(1,2,3,4)) == ()
 
 @test_nowarn SoleLogics.Interval(1,2)
+@test_nowarn SoleLogics.Interval(0,3)
+@test_throws ErrorException SoleLogics.Interval(2,2)
+@test_throws ErrorException SoleLogics.Interval(3,2)
 @test_nowarn SoleLogics.Interval((1,2),)
 @test SoleLogics.goeswithdim(SoleLogics.Interval(1,2), 1)
 @test !SoleLogics.goeswithdim(SoleLogics.Interval(1,2), 2)


### PR DESCRIPTION
## Summary

Closes #47 by validating `Interval` endpoints in its inner constructor: construction now requires `x < y`.

- Added regression coverage for valid, zero-origin, degenerate, and reversed intervals.
- `Interval2D` and other world types were not modified.
- Repository constructors and interval enumeration only produce ordered endpoints; no in-repository use of degenerate or reversed intervals was found. Existing `Interval(-1, 0)` usage remains valid because this change does not impose positivity.

## Validation

- Before: `julia --project=. -e 'using Pkg; Pkg.test()'` — passed (114986 pass, 16 broken, 115002 total).
- After: same command — passed (114989 pass, 16 broken, 115005 total). The 16 broken tests are pre-existing.

## Maintainer questions

This implements the narrowest interpretation of #47. Please confirm whether maintainers instead want:

1. `x < y` only, or the stronger `x > 0 && y > 0 && x < y` positivity constraint?
2. The check always enabled, or gated to debug/check-bounds mode?
3. Any ecosystem callers that intentionally construct degenerate or reversed intervals?
